### PR TITLE
Feature update details deactivate restaurant

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ DB_HOST=your_database_host
 DB_USER=your_database_user
 DB_PASSWORD=your_database_password
 DB_NAME=your_database_name
+GOOGLE_API_KEY=your_google_cloud_api_key

--- a/src/controllers/Controller.js
+++ b/src/controllers/Controller.js
@@ -270,6 +270,11 @@ module.exports = class Controller {
         if (err) {
           response(res, { status: 401, data: { message: 'Unauthorized' } });
         } else {
+
+          if (decoded.restaurant_id !== parseInt(restaurantID)) {
+            response(res, { status: 403, data: { message: 'Forbidden: Cannot view notifications for other restaurants.' } });
+            return;
+        }
           const notifications = await dbRepo.getNotificationsByRestaurantID(restaurant_id);
           const data = notifications.length ? notifications : `No notifications found for RestaurantID: ${restaurant_id}`;
           response(res, { data });
@@ -324,6 +329,62 @@ module.exports = class Controller {
         response(res, { status: 400, data: { message: error.message } });
     }
   }
+
+  async updateRestaurantDetails(req, res) {
+    try {
+        const { restaurantID } = req.params;
+        const token = req.headers.authorization;
+        const updatedDetails = req.body; 
+
+        jwt.verify(token, secretKey, async (err, decoded) => {
+            if (err) {
+                response(res, { status: 401, data: { message: 'Unauthorized' } });
+            } else {
+                
+                if (decoded.restaurant_id !== parseInt(restaurantID)) {
+                    return response(res, { status: 403, data: { message: 'Permission denied. You can only update your own restaurant details.' } });
+                }
+
+                const result = await dbRepo.updateRestaurantDetails(restaurantID, updatedDetails);
+
+                if (result) {
+                    response(res, { data: "Restaurant details updated successfully!" });
+                } else {
+                    throw new Error("Failed to update restaurant details.");
+                }
+            }
+        });
+    } catch (error) {
+        response(res, { status: 400, data: { message: error.message } });
+    }
+  }
+
+
+  async deactivateRestaurant(req, res) {
+    try {
+        const { restaurantID } = req.params;
+        const token = req.headers.authorization;
+
+        jwt.verify(token, secretKey, async (err, decoded) => {
+            if (err) {
+                response(res, { status: 401, data: { message: 'Unauthorized' } });
+            } else if (decoded.restaurant_id !== parseInt(restaurantID)) {
+                response(res, { status: 403, data: { message: 'Forbidden: You do not have permission to deactivate this restaurant.' } });
+            } else {
+                const result = await dbRepo.deactivateRestaurant(restaurantID);
+                if (result.affectedRows > 0) {
+                    response(res, { data: "Restaurant deactivated successfully!" });
+                } else {
+                    throw new Error("Failed to deactivate the restaurant.");
+                }
+            }
+        });
+    } catch (error) {
+        response(res, { status: 400, data: { message: error.message } });
+    }
+}
+
+
 
   async addMenuItem(req, res) {
     try {

--- a/src/controllers/Controller.js
+++ b/src/controllers/Controller.js
@@ -28,4 +28,16 @@ module.exports = class Controller {
       response(res, { status: 400, data: error.message });
     }
   }
+
+  async getRestaurantNotifications(req, res) {
+    try {
+        const { restaurant_id } = req.params;
+        const notifications = await dbRepo.getNotificationsByRestaurantID(restaurant_id);
+        const data = notifications.length ? notifications : `No notifications found for RestaurantID: ${restaurant_id}`;
+        response(res, { data });
+    } catch (error) {
+        response(res, { status: 400, data: error.message });
+    }
+}
+
 };

--- a/src/db/RUEatsRepository.js
+++ b/src/db/RUEatsRepository.js
@@ -34,4 +34,17 @@ module.exports = class RUEatsRepository {
       );
     });
   }
+
+  getNotificationsByRestaurantID(restaurantID) {
+    return new Promise((resolve, reject) => {
+        this.connection.query('SELECT * FROM orders WHERE restaurant_id = ?', [restaurantID], function (error, results, fields) {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(results);
+            }
+        });
+    });
+}
+
 };

--- a/src/db/RUEatsRepository.js
+++ b/src/db/RUEatsRepository.js
@@ -255,6 +255,20 @@ module.exports = class RUEatsRepository {
     });
   }
 
+  deactivateRestaurant(restaurantID) {
+    return new Promise((resolve, reject) => {
+        this.connection.query('UPDATE restaurants SET is_active = 0 WHERE restaurant_id = ?', [restaurantID], function (error, results) {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(results);
+            }
+        });
+    });
+}
+
+
+
   getInsightsByRestaurantID(restaurantID) {
     return new Promise(async (resolve, reject) => {
         try {
@@ -356,5 +370,40 @@ module.exports = class RUEatsRepository {
       );
     });
   }
+
+  updateRestaurantDetails(restaurantID, updatedDetails) {
+    return new Promise((resolve, reject) => {
+        // Check if there's anything to update
+        if (Object.keys(updatedDetails).length === 0) {
+            resolve(false);
+            return;
+        }
+
+        let queryString = 'UPDATE restaurants SET ';
+        const queryParams = [];
+        const updateFields = [];
+
+        // Build the dynamic query
+        for (const [key, value] of Object.entries(updatedDetails)) {
+            if (["name", "email", "phone_number", "address", "cuisine_type", "rating", "operating_hours", "is_active"].includes(key)) {
+                updateFields.push(`${key} = ?`);
+                queryParams.push(value);
+            }
+        }
+
+        queryString += updateFields.join(', ');
+        queryString += ' WHERE restaurant_id = ?';
+        queryParams.push(restaurantID);
+
+        this.connection.query(queryString, queryParams, function (error, results, fields) {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(results.affectedRows > 0);
+            }
+        });
+    });
+}
+
 }
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -112,6 +112,18 @@ const routes = {
         DELETE : controller.deleteMenuItem
     },
 
+    "/deactivate-restaurant/:restaurantID": {
+      PATCH : controller.deactivateRestaurant
+    },
+  
+  
+
+    "/update-restaurant/:restaurantID" : {
+      PUT : (req, res) => {
+          validatePostRequests(req, res, controller.updateRestaurantDetails);
+      },
+  },
+
     notFound : (_req, res) => {
         response(res, {status : 404, data : "Requested URL not found"});
     }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -14,6 +14,10 @@ const routes = {
   "/restaurants": {
     GET: controller.getAllRestaurants,
   },
+  "/get-notifications/:restaurant_id/notifications": {
+    GET: controller.getRestaurantNotifications
+  },
+
 
   notFound: (_req, res) => {
     response(res, { status: 404, data: "Requested URL not found" });

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -115,17 +115,6 @@ const routes = {
         DELETE : controller.deleteMenuItem
     },
 
-    "/deactivate-restaurant/:restaurantID": {
-      PATCH : controller.deactivateRestaurant
-    },
-  
-  
-
-    "/update-restaurant/:restaurantID" : {
-      PUT : (req, res) => {
-          validatePostRequests(req, res, controller.updateRestaurantDetails);
-      },
-  },
 
     "/deactivate-restaurant/:restaurantID": {
       PATCH : controller.deactivateRestaurant
@@ -161,6 +150,7 @@ const routes = {
 
     notFound: (_req, res) => {
         response(res, { status: 404, data: "Requested URL not found" });
+
     }
 }
 module.exports = routes


### PR DESCRIPTION
- Features to update restaurant 
   - details like operating hours or even name and email. 
   - I felt that updating password should be done separately, as it usually requires more verification.
- Features to deactivate a restaurant.
   - The API defined in the API specifications document suggests that the restaurant owner should be able to 'delete' his own restaurant. But restaurant_id is a foreign key in multiple tables, and we would need to cascade the operation. This would cause a lot of problems, as we would need to ALTER all the tables with restaurant_id as the foreign key.
   - Instead, I have made it an UPDATE. The restaurant owner can 'deactivate' their account, and the boolean '**is_active**' will be set to 0. This would be much safer.
   - In this case, the only person that can actually delete the restaurant would be the app administrator. If you guys have any ideas regarding this, lets discuss. 

**Deactivating a restaurant with the correct ID**
![deactivate_restaurant](https://github.com/567-Software-Engineering/RUEats/assets/52864198/84266e60-f162-4a7e-a217-f7e42d8a0e10)
**Attempt to deactivate others' account.**
![forbidden_deactivate](https://github.com/567-Software-Engineering/RUEats/assets/52864198/6952d905-1794-41e9-9762-9a0b12c0f1e4)
**Attempt to update others' account**
![Forbidden_update](https://github.com/567-Software-Engineering/RUEats/assets/52864198/08453fb4-caf8-49c5-ab56-16a14efd428b)
**Valid update**
![Proper_update](https://github.com/567-Software-Engineering/RUEats/assets/52864198/f4c91511-4328-483f-bac7-052f9d58233b)
**Updating without logging in**
![unauthorized_update](https://github.com/567-Software-Engineering/RUEats/assets/52864198/4144b402-27fd-4b1c-aec0-79fe5430ea5b)
